### PR TITLE
[CLOUDTRUST-5523] Change pipeline name

### DIFF
--- a/build.pipeline
+++ b/build.pipeline
@@ -1,1 +1,1 @@
-goLibBuildPipeline('back-kafka-client', true, 'ssh://git@github.com/cloudtrust/kafka-client')
+goLibBuildPipeline('kafka-client', true, 'ssh://git@github.com/cloudtrust/kafka-client')


### PR DESCRIPTION
The SonarQube key is assigned for the repo "kafka-client", hence it does not work without this change.