### PR TITLE
[CLOUDTRUST-5964] Consumers: Add initial offset config parameter

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -89,7 +89,7 @@ func (c *cluster) Close() error {
 	return anError
 }
 
-func (c *cluster) getConsumerGroup(consumerGroupName string, config *sarama.Config) (sarama.ConsumerGroup, error) {
+func (c *cluster) getConsumerGroup(consumerGroupName string, groupConfig sarama.Config) (sarama.ConsumerGroup, error) {
 	if !c.enabled {
 		return &misc.NoopKafkaConsumerGroup{}, nil
 	}
@@ -97,12 +97,7 @@ func (c *cluster) getConsumerGroup(consumerGroupName string, config *sarama.Conf
 		return cg, nil
 	}
 
-	groupConfig := config
-	if groupConfig == nil {
-		groupConfig = c.saramaConfig
-	}
-
-	consumer, err := sarama.NewConsumerGroup(c.brokers, consumerGroupName, groupConfig)
+	consumer, err := sarama.NewConsumerGroup(c.brokers, consumerGroupName, &groupConfig)
 	if err != nil {
 		c.logger.Warn(context.Background(), "msg", "Failed to create consumer group", "group", consumerGroupName, "err", err)
 		return nil, err

--- a/cluster.go
+++ b/cluster.go
@@ -89,7 +89,7 @@ func (c *cluster) Close() error {
 	return anError
 }
 
-func (c *cluster) getConsumerGroup(consumerGroupName string) (sarama.ConsumerGroup, error) {
+func (c *cluster) getConsumerGroup(consumerGroupName string, config *sarama.Config) (sarama.ConsumerGroup, error) {
 	if !c.enabled {
 		return &misc.NoopKafkaConsumerGroup{}, nil
 	}
@@ -97,7 +97,12 @@ func (c *cluster) getConsumerGroup(consumerGroupName string) (sarama.ConsumerGro
 		return cg, nil
 	}
 
-	consumer, err := sarama.NewConsumerGroup(c.brokers, consumerGroupName, c.saramaConfig)
+	groupConfig := config
+	if groupConfig == nil {
+		groupConfig = c.saramaConfig
+	}
+
+	consumer, err := sarama.NewConsumerGroup(c.brokers, consumerGroupName, groupConfig)
 	if err != nil {
 		c.logger.Warn(context.Background(), "msg", "Failed to create consumer group", "group", consumerGroupName, "err", err)
 		return nil, err

--- a/configuration.go
+++ b/configuration.go
@@ -122,5 +122,9 @@ func (kcr *KafkaConsumerRepresentation) Validate() error {
 	if kcr.FailureProducer != nil && *kcr.FailureProducer == "" {
 		return errors.New("consumer failure producer is optional but should not be empty")
 	}
+	if kcr.InitialOffset != nil && !(*kcr.InitialOffset == "oldest" || *kcr.InitialOffset == "newest") {
+		return errors.New("consumer initial offset is optional but should be either 'oldest' or 'newest'")
+	}
+
 	return nil
 }

--- a/configuration.go
+++ b/configuration.go
@@ -40,6 +40,7 @@ type KafkaConsumerRepresentation struct {
 	ConsumerGroupName *string        `mapstructure:"consumer-group-name"`
 	FailureProducer   *string        `mapstructure:"failure-producer"`
 	ConsumptionDelay  *time.Duration `mapstructure:"consumption-delay"`
+	InitialOffset     *string        `mapstructure:"initial-offset"`
 }
 
 // Validate validates a KafkaClusterRepresentation instance

--- a/configuration.go
+++ b/configuration.go
@@ -5,6 +5,11 @@ import (
 	"time"
 )
 
+const (
+	offsetNewestParam = "newest"
+	offsetOldestParam = "oldest"
+)
+
 // KafkaClusterRepresentation struct
 type KafkaClusterRepresentation struct {
 	ID               *string                       `mapstructure:"id"`
@@ -122,7 +127,7 @@ func (kcr *KafkaConsumerRepresentation) Validate() error {
 	if kcr.FailureProducer != nil && *kcr.FailureProducer == "" {
 		return errors.New("consumer failure producer is optional but should not be empty")
 	}
-	if kcr.InitialOffset != nil && !(*kcr.InitialOffset == "oldest" || *kcr.InitialOffset == "newest") {
+	if kcr.InitialOffset != nil && !(*kcr.InitialOffset == offsetOldestParam || *kcr.InitialOffset == offsetNewestParam) {
 		return errors.New("consumer initial offset is optional but should be either 'oldest' or 'newest'")
 	}
 

--- a/configuration_test.go
+++ b/configuration_test.go
@@ -54,7 +54,7 @@ func TestValidateCluster(t *testing.T) {
 
 	var emptyString = ptrString("")
 	var invalidCases []KafkaClusterRepresentation
-	for range 32 {
+	for range 36 {
 		invalidCases = append(invalidCases, createValidKafkaClusterRepresentation())
 	}
 	invalidCases[0].ID = nil
@@ -83,31 +83,21 @@ func TestValidateCluster(t *testing.T) {
 	invalidCases[22].Consumers[0].ConsumerGroupName = nil
 	invalidCases[23].Consumers[0].ConsumerGroupName = emptyString
 	invalidCases[24].Consumers[0].FailureProducer = emptyString
-	invalidCases[25].Consumers[1].ID = nil
-	invalidCases[26].Consumers[1].ID = emptyString
-	invalidCases[27].Consumers[1].Topic = nil
-	invalidCases[28].Consumers[1].Topic = emptyString
-	invalidCases[29].Consumers[1].ConsumerGroupName = nil
-	invalidCases[30].Consumers[1].ConsumerGroupName = emptyString
-	invalidCases[31].Consumers[1].FailureProducer = emptyString
+	invalidCases[25].Consumers[0].InitialOffset = ptrString("not oldest nor newest")
+	invalidCases[26].Consumers[0].InitialOffset = emptyString
+	invalidCases[27].Consumers[1].ID = nil
+	invalidCases[28].Consumers[1].ID = emptyString
+	invalidCases[29].Consumers[1].Topic = nil
+	invalidCases[30].Consumers[1].Topic = emptyString
+	invalidCases[31].Consumers[1].ConsumerGroupName = nil
+	invalidCases[32].Consumers[1].ConsumerGroupName = emptyString
+	invalidCases[33].Consumers[1].FailureProducer = emptyString
+	invalidCases[34].Consumers[1].InitialOffset = ptrString("not oldest nor newest")
+	invalidCases[35].Consumers[0].InitialOffset = emptyString
 
 	for idx, value := range invalidCases {
 		t.Run(fmt.Sprintf("Invalid case #%d", idx), func(t *testing.T) {
 			assert.NotNil(t, value.Validate())
-		})
-	}
-
-	var offsetCases []KafkaClusterRepresentation
-	for range 4 {
-		offsetCases = append(offsetCases, createValidKafkaClusterRepresentation())
-	}
-	offsetCases[0].Consumers[0].InitialOffset = nil
-	offsetCases[1].Consumers[0].InitialOffset = emptyString
-	offsetCases[2].Consumers[1].InitialOffset = nil
-	offsetCases[3].Consumers[1].InitialOffset = emptyString
-	for idx, value := range offsetCases {
-		t.Run(fmt.Sprintf("Offset case #%d", idx), func(t *testing.T) {
-			assert.Nil(t, value.Validate())
 		})
 	}
 

--- a/configuration_test.go
+++ b/configuration_test.go
@@ -32,8 +32,17 @@ func createValidKafkaClusterRepresentation() KafkaClusterRepresentation {
 				ID:                ptrString("consumer-1"),
 				Enabled:           ptrBool(true),
 				Topic:             ptrString("topic-consumer-1"),
-				ConsumerGroupName: ptrString("consumer-group"),
+				ConsumerGroupName: ptrString("consumer-group-1"),
 				FailureProducer:   ptrString("producer-1"),
+				InitialOffset:     nil,
+			},
+			{
+				ID:                ptrString("consumer-2"),
+				Enabled:           ptrBool(true),
+				Topic:             ptrString("topic-consumer-2"),
+				ConsumerGroupName: ptrString("consumer-group-2"),
+				FailureProducer:   ptrString("producer-1"),
+				InitialOffset:     ptrString("newest"),
 			},
 		},
 	}
@@ -45,7 +54,7 @@ func TestValidateCluster(t *testing.T) {
 
 	var emptyString = ptrString("")
 	var invalidCases []KafkaClusterRepresentation
-	for i := 0; i < 25; i++ {
+	for range 32 {
 		invalidCases = append(invalidCases, createValidKafkaClusterRepresentation())
 	}
 	invalidCases[0].ID = nil
@@ -74,10 +83,32 @@ func TestValidateCluster(t *testing.T) {
 	invalidCases[22].Consumers[0].ConsumerGroupName = nil
 	invalidCases[23].Consumers[0].ConsumerGroupName = emptyString
 	invalidCases[24].Consumers[0].FailureProducer = emptyString
+	invalidCases[25].Consumers[1].ID = nil
+	invalidCases[26].Consumers[1].ID = emptyString
+	invalidCases[27].Consumers[1].Topic = nil
+	invalidCases[28].Consumers[1].Topic = emptyString
+	invalidCases[29].Consumers[1].ConsumerGroupName = nil
+	invalidCases[30].Consumers[1].ConsumerGroupName = emptyString
+	invalidCases[31].Consumers[1].FailureProducer = emptyString
 
 	for idx, value := range invalidCases {
 		t.Run(fmt.Sprintf("Invalid case #%d", idx), func(t *testing.T) {
 			assert.NotNil(t, value.Validate())
 		})
 	}
+
+	var offsetCases []KafkaClusterRepresentation
+	for range 4 {
+		offsetCases = append(offsetCases, createValidKafkaClusterRepresentation())
+	}
+	offsetCases[0].Consumers[0].InitialOffset = nil
+	offsetCases[1].Consumers[0].InitialOffset = emptyString
+	offsetCases[2].Consumers[1].InitialOffset = nil
+	offsetCases[3].Consumers[1].InitialOffset = emptyString
+	for idx, value := range offsetCases {
+		t.Run(fmt.Sprintf("Offset case #%d", idx), func(t *testing.T) {
+			assert.Nil(t, value.Validate())
+		})
+	}
+
 }

--- a/consumer.go
+++ b/consumer.go
@@ -55,9 +55,9 @@ func newConsumer(cluster *cluster, consumerRep KafkaConsumerRepresentation, logg
 
 	var initialOffset = sarama.OffsetOldest
 	if consumerRep.InitialOffset != nil {
-		if *consumerRep.InitialOffset == "newest" {
+		if *consumerRep.InitialOffset == offsetNewestParam {
 			initialOffset = sarama.OffsetNewest
-		} else if *consumerRep.InitialOffset == "oldest" {
+		} else if *consumerRep.InitialOffset == offsetOldestParam {
 			initialOffset = sarama.OffsetOldest
 		}
 	}
@@ -106,21 +106,16 @@ func (c *consumer) initialize() error {
 		return nil
 	}
 
-	var config *sarama.Config
-
+	groupConfig := *c.cluster.saramaConfig
 	if c.initialOffset == sarama.OffsetNewest {
-		copy := *c.cluster.saramaConfig
-		copy.Consumer.Offsets.Initial = sarama.OffsetNewest
-		config = &copy
+		groupConfig.Consumer.Offsets.Initial = sarama.OffsetNewest
 	} else if c.initialOffset == sarama.OffsetOldest {
-		copy := *c.cluster.saramaConfig
-		copy.Consumer.Offsets.Initial = sarama.OffsetOldest
-		config = &copy
+		groupConfig.Consumer.Offsets.Initial = sarama.OffsetOldest
 	}
 
 	// Consumer group
 	var err error
-	if c.consumerGroup, err = c.cluster.getConsumerGroup(c.consumerGroupName, config); err != nil {
+	if c.consumerGroup, err = c.cluster.getConsumerGroup(c.consumerGroupName, groupConfig); err != nil {
 		return err
 	}
 	// Done

--- a/consumer.go
+++ b/consumer.go
@@ -54,8 +54,12 @@ func newConsumer(cluster *cluster, consumerRep KafkaConsumerRepresentation, logg
 	groupName = strings.Replace(groupName, "<UUID>", uuid.New().String(), 1)
 
 	var initialOffset = sarama.OffsetOldest
-	if consumerRep.InitialOffset != nil && *consumerRep.InitialOffset == "newest" {
-		initialOffset = sarama.OffsetNewest
+	if consumerRep.InitialOffset != nil {
+		if *consumerRep.InitialOffset == "newest" {
+			initialOffset = sarama.OffsetNewest
+		} else if *consumerRep.InitialOffset == "oldest" {
+			initialOffset = sarama.OffsetOldest
+		}
 	}
 
 	return &consumer{
@@ -107,6 +111,10 @@ func (c *consumer) initialize() error {
 	if c.initialOffset == sarama.OffsetNewest {
 		copy := *c.cluster.saramaConfig
 		copy.Consumer.Offsets.Initial = sarama.OffsetNewest
+		config = &copy
+	} else if c.initialOffset == sarama.OffsetOldest {
+		copy := *c.cluster.saramaConfig
+		copy.Consumer.Offsets.Initial = sarama.OffsetOldest
 		config = &copy
 	}
 


### PR DESCRIPTION
Relates to point 3 of https://projectportal.elca.ch/jira/browse/CLOUDTRUST-5964

It adds a config parameter `initial-offset` for Kafka consumers

The consumer's initial offset can be set either to
- `sarama.OffsetNewest` if specified in the config parameter (`"newest"`)
- `sarama.OffsetOldest` if specified in the config parameter (`"oldest"`) OR if this parameter is absent from the config, so this is the default case.